### PR TITLE
Make the tileset compatible with Freeciv 2.6

### DIFF
--- a/RoundSquare.tilespec
+++ b/RoundSquare.tilespec
@@ -301,6 +301,7 @@ styles =
       "tx.farmland",   "Cardinals"
       "tx.mine",       "Single1"
       "tx.oil_mine",   "Single1"
+      "tx.oil_rig",    "Single1"
       "tx.pollution",  "Single2"
       "tx.fallout",    "Single2"
       "tx.village",    "Single1"
@@ -308,5 +309,6 @@ styles =
       "base.fortress", "3Layer"
       "base.airstrip", "3Layer"
       "base.airbase",  "3Layer"
+      "base.buoy",     "3Layer"
       "base.ruins",    "3Layer"
     }

--- a/RoundSquare/units.spec
+++ b/RoundSquare/units.spec
@@ -8,7 +8,7 @@ options = "+Freeciv-2.6-spec"
 
 artists = "
     Tatu Rissanen <tatu.rissanen@hut.fi>
-    The Square Cow (u.refugee)
+    The Square Cow (u.migrants)
 "
 
 [file]
@@ -77,5 +77,6 @@ tiles = { "row", "column", "tag"
   2, 13, "u.awacs"
   2, 14, "u.worker"
   2, 15, "u.leader"
-  2, 16, "u.refugee"
+  ;2, 16, "u.refugee"
+  2, 16, "u.migrants"
 }


### PR DESCRIPTION
I made these changes to make `RoundSquare` work with the [Longturn SIM26 ruleset](https://github.com/longturn/games/tree/master/SIM26), the simulation ruleset for Freeciv 2.6. The updated tileset also seems to work well with the standard rulesets of Freeciv 2.6 (I did not test all of them).