### PR TITLE
Fix the location of tx.fog

### DIFF
--- a/RoundSquare/tiles.spec
+++ b/RoundSquare/tiles.spec
@@ -420,7 +420,7 @@ tiles = { "row", "column", "tag"
  12, 13, "tx.darkness_n1e0s1w1"
  12, 14, "tx.darkness_n0e1s1w1"
  12, 15, "tx.darkness_n1e1s1w1"
- 14, 5, "tx.fog"
+ 14, 4, "tx.fog"
 
 
 ; Rivers (as special type), and whether north, south, east, west 


### PR DESCRIPTION
This sprite is used to draw fog on the minimap. It was pointing to a fully transparent sprite; set it to point to the correct location (semi-transparent black).

Tested with fc21 but I suppose 2.6 has the same behavior.